### PR TITLE
[FE] 플레이어 토큰 이동기능 구현

### DIFF
--- a/fe/src/components/GameBoard/Cell.tsx
+++ b/fe/src/components/GameBoard/Cell.tsx
@@ -23,7 +23,7 @@ export default function Cell({ theme, name, logo, sharePrice }: Cellprops) {
       )}
       <Content>
         {!theme && <CellImg src={cellImageMap[logo]} />}
-        {sharePrice && <Price>{addCommasToNumber(sharePrice)}</Price>}
+        {sharePrice && <span>{addCommasToNumber(sharePrice)}</span>}
       </Content>
     </Container>
   );
@@ -65,5 +65,3 @@ const Content = styled.div`
   justify-content: center;
   align-items: center;
 `;
-
-const Price = styled.div``;

--- a/fe/src/components/GameBoard/GameBoard.tsx
+++ b/fe/src/components/GameBoard/GameBoard.tsx
@@ -10,7 +10,7 @@ import { RefObject, useRef, useState } from 'react';
 import { styled } from 'styled-components';
 import Cell from './Cell';
 import PlayerToken from './PlayerToken';
-import { CELL, CORNER_CELLS, TOKEN_TRANSITION_DELAY } from './constants';
+import { CORNER_CELLS, TOKEN_TRANSITION_DELAY, directions } from './constants';
 
 export default function GameBoard() {
   const [dice, setDice] = useState(0);
@@ -66,13 +66,6 @@ export default function GameBoard() {
       tokenCoordinates.x += x;
       tokenCoordinates.y += y;
       tokenRef.current!.style.transform = `translate(${tokenCoordinates.x}rem, ${tokenCoordinates.y}rem)`;
-    };
-
-    const directions = {
-      top: { x: 0, y: -CELL.HEIGHT },
-      right: { x: CELL.WIDTH, y: 0 },
-      bottom: { x: 0, y: CELL.HEIGHT },
-      left: { x: -CELL.HEIGHT, y: 0 },
     };
 
     for (let i = diceCount; i > 0; i--) {

--- a/fe/src/components/GameBoard/GameBoard.tsx
+++ b/fe/src/components/GameBoard/GameBoard.tsx
@@ -1,3 +1,4 @@
+import { delay } from '@utils/index';
 import { useRef, useState } from 'react';
 import { styled } from 'styled-components';
 import Cell from './Cell';
@@ -7,7 +8,7 @@ type DirectionType = 'top' | 'right' | 'bottom' | 'left';
 export default function GameBoard() {
   const [dice, setDice] = useState(0);
   const tokenRef = useRef<HTMLDivElement>(null);
-  const coordinates = useRef({ x: 0, y: 0 });
+  const tokenCoordinates = useRef({ x: 0, y: 0 });
   const isStart = useRef(true);
   const currentCell = useRef(0);
   const direction = useRef<DirectionType>('top');
@@ -46,27 +47,27 @@ export default function GameBoard() {
 
       switch (direction.current) {
         case 'top':
-          coordinates.current.y -= 6;
-          tokenRef.current!.style.transform = `translate(${coordinates.current.x}rem, ${coordinates.current.y}rem)`;
+          tokenCoordinates.current.y -= 6;
+          tokenRef.current!.style.transform = `translate(${tokenCoordinates.current.x}rem, ${tokenCoordinates.current.y}rem)`;
           break;
         case 'right':
-          coordinates.current.x += 6;
-          tokenRef.current!.style.transform = `translate(${coordinates.current.x}rem, ${coordinates.current.y}rem)`;
+          tokenCoordinates.current.x += 6;
+          tokenRef.current!.style.transform = `translate(${tokenCoordinates.current.x}rem, ${tokenCoordinates.current.y}rem)`;
           break;
         case 'bottom':
-          coordinates.current.y += 6;
-          tokenRef.current!.style.transform = `translate(${coordinates.current.x}rem, ${coordinates.current.y}rem)`;
+          tokenCoordinates.current.y += 6;
+          tokenRef.current!.style.transform = `translate(${tokenCoordinates.current.x}rem, ${tokenCoordinates.current.y}rem)`;
           break;
         case 'left':
-          coordinates.current.x -= 6;
-          tokenRef.current!.style.transform = `translate(${coordinates.current.x}rem, ${coordinates.current.y}rem)`;
+          tokenCoordinates.current.x -= 6;
+          tokenRef.current!.style.transform = `translate(${tokenCoordinates.current.x}rem, ${tokenCoordinates.current.y}rem)`;
           break;
         default:
           break;
       }
       currentCell.current = (currentCell.current + 1) % 24;
       isStart.current = false;
-      await new Promise((resolve) => setTimeout(resolve, 200));
+      await delay(200);
     }
   };
   return (
@@ -187,16 +188,16 @@ export default function GameBoard() {
 const Board = styled.div`
   width: 42rem;
   height: 42rem;
-  border-color: ${({ theme: { color } }) => color.accentText};
   position: relative;
+  border-color: ${({ theme: { color } }) => color.accentText};
 `;
 
 const Line1 = styled.div`
-  display: flex;
-  flex-direction: column-reverse;
   position: absolute;
   top: 6rem;
   left: 0;
+  display: flex;
+  flex-direction: column-reverse;
 
   div {
     border-top: none;
@@ -204,10 +205,10 @@ const Line1 = styled.div`
 `;
 
 const Line2 = styled.div`
-  display: flex;
-  flex-direction: row;
   position: absolute;
   top: 0;
+  display: flex;
+  flex-direction: row;
 
   div {
     border-right: none;
@@ -215,10 +216,10 @@ const Line2 = styled.div`
 `;
 
 const Line3 = styled.div`
-  display: flex;
-  flex-direction: column;
   position: absolute;
   right: 0;
+  display: flex;
+  flex-direction: column;
 
   div {
     border-bottom: none;
@@ -226,11 +227,11 @@ const Line3 = styled.div`
 `;
 
 const Line4 = styled.div`
-  display: flex;
-  flex-direction: row-reverse;
   position: absolute;
   bottom: 0;
   left: 6rem;
+  display: flex;
+  flex-direction: row-reverse;
 
   div {
     border-left: none;
@@ -246,23 +247,22 @@ const RollButton = styled.button`
 const Center = styled.div`
   width: 30rem;
   height: 30rem;
+  position: absolute;
+  top: 6rem;
+  left: 6rem;
   display: flex;
   flex-direction: column;
   justify-content: space-around;
   align-items: center;
-  position: absolute;
-  top: 6rem;
-  left: 6rem;
 `;
 
 const PlayerToken = styled.div`
-  width: 3rem;
-  height: 3rem;
+  width: 2rem;
+  height: 2rem;
+  position: absolute;
+  bottom: 0.5rem;
+  left: 0.5rem;
   border-radius: 50%;
   background-color: red;
-  position: absolute;
-  bottom: 1.5rem;
-  left: 1.5rem;
-
   transition: all 0.2s;
 `;

--- a/fe/src/components/GameBoard/GameBoard.tsx
+++ b/fe/src/components/GameBoard/GameBoard.tsx
@@ -5,14 +5,12 @@ import {
   usePlayerToken3,
   usePlayerToken4,
 } from '@store/playerToken';
-import { delay } from '@utils/index';
+import { changeDirection, delay } from '@utils/index';
 import { RefObject, useRef, useState } from 'react';
 import { styled } from 'styled-components';
 import Cell from './Cell';
 import PlayerToken from './PlayerToken';
 import { CELL, CORNER_CELLS, TOKEN_TRANSITION_DELAY } from './constants';
-
-export type DirectionType = 'top' | 'right' | 'bottom' | 'left';
 
 export default function GameBoard() {
   const [dice, setDice] = useState(0);
@@ -34,16 +32,16 @@ export default function GameBoard() {
 
     switch (order) {
       case 1:
-        moveToken(randomNum, token1, setToken1, tokenRef1);
+        moveToken(randomNum, tokenRef1, token1, setToken1);
         break;
       case 2:
-        moveToken(randomNum, token2, setToken2, tokenRef2);
+        moveToken(randomNum, tokenRef2, token2, setToken2);
         break;
       case 3:
-        moveToken(randomNum, token3, setToken3, tokenRef3);
+        moveToken(randomNum, tokenRef3, token3, setToken3);
         break;
       case 4:
-        moveToken(randomNum, token4, setToken4, tokenRef4);
+        moveToken(randomNum, tokenRef4, token4, setToken4);
         break;
       default:
         break;
@@ -52,28 +50,13 @@ export default function GameBoard() {
     setDice(randomNum);
   };
 
-  const changeDirection = (direction: DirectionType) => {
-    switch (direction) {
-      case 'top':
-        return 'right';
-      case 'right':
-        return 'bottom';
-      case 'bottom':
-        return 'left';
-      case 'left':
-        return 'top';
-      default:
-        return 'top';
-    }
-  };
-
   const moveToken = async (
     diceCount: number,
+    tokenRef: RefObject<HTMLDivElement>,
     tokenAtom: PlayerTokenAtom,
     setTokenAtom: (
       updateFunction: (prev: PlayerTokenAtom) => PlayerTokenAtom
-    ) => void,
-    tokenRef: RefObject<HTMLDivElement>
+    ) => void
   ) => {
     const tokenCoordinates = tokenAtom.coordinates;
     let tokenDirection = tokenAtom.direction;

--- a/fe/src/components/GameBoard/GameBoard.tsx
+++ b/fe/src/components/GameBoard/GameBoard.tsx
@@ -1,119 +1,192 @@
+import { useRef, useState } from 'react';
 import { styled } from 'styled-components';
 import Cell from './Cell';
 
+type DirectionType = 'top' | 'right' | 'bottom' | 'left';
+
 export default function GameBoard() {
+  const [dice, setDice] = useState(0);
+  const tokenRef = useRef<HTMLDivElement>(null);
+  const coordinates = useRef({ x: 0, y: 0 });
+  const isStart = useRef(true);
+  const currentCell = useRef(0);
+  const direction = useRef<DirectionType>('top');
+
+  const throwDice = () => {
+    const randomNum = Math.floor(Math.random() * 11) + 2;
+    setDice(randomNum);
+    moveToken(randomNum);
+  };
+
+  const changeDirection = (direction: DirectionType) => {
+    switch (direction) {
+      case 'top':
+        return 'right';
+      case 'right':
+        return 'bottom';
+      case 'bottom':
+        return 'left';
+      case 'left':
+        return 'top';
+      default:
+        return 'top';
+    }
+  };
+
+  const moveToken = async (주사위눈: number) => {
+    for (let i = 주사위눈; i > 0; i--) {
+      if (
+        (!isStart.current && currentCell.current === 0) ||
+        currentCell.current === 6 ||
+        currentCell.current === 12 ||
+        currentCell.current === 18
+      ) {
+        direction.current = changeDirection(direction.current);
+      }
+
+      switch (direction.current) {
+        case 'top':
+          coordinates.current.y -= 6;
+          tokenRef.current!.style.transform = `translate(${coordinates.current.x}rem, ${coordinates.current.y}rem)`;
+          break;
+        case 'right':
+          coordinates.current.x += 6;
+          tokenRef.current!.style.transform = `translate(${coordinates.current.x}rem, ${coordinates.current.y}rem)`;
+          break;
+        case 'bottom':
+          coordinates.current.y += 6;
+          tokenRef.current!.style.transform = `translate(${coordinates.current.x}rem, ${coordinates.current.y}rem)`;
+          break;
+        case 'left':
+          coordinates.current.x -= 6;
+          tokenRef.current!.style.transform = `translate(${coordinates.current.x}rem, ${coordinates.current.y}rem)`;
+          break;
+        default:
+          break;
+      }
+      currentCell.current = (currentCell.current + 1) % 24;
+      isStart.current = false;
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+  };
   return (
-    <Board>
-      <Line1>
-        <Cell logo="start" name="start" />
-        <Cell
-          theme="it"
-          name="코드스쿼드"
-          logo="codesquad"
-          sharePrice={400000}
-        />
-        <Cell
-          theme="fashion"
-          name="무신사"
-          logo="musinsa"
-          sharePrice={500000}
-        />
-        <Cell
-          theme="travel"
-          name="하나투어"
-          logo="hanatour"
-          sharePrice={600000}
-        />
-        <Cell
-          theme="construction"
-          name="GS건설"
-          logo="gs"
-          sharePrice={700000}
-        />
-        <Cell theme="food" name="농심" logo="nongshim" sharePrice={800000} />
-      </Line1>
-      <Line2>
-        <Cell logo="jail" name="유치장" />
-        <Cell
-          theme="construction"
-          name="현대건설"
-          logo="hyundai"
-          sharePrice={900000}
-        />
-        <Cell
-          theme="military"
-          name="한화디펜스"
-          logo="hanwha"
-          sharePrice={1000000}
-        />
-        <Cell name="황금카드" logo="goldCard" />
-        <Cell
-          theme="travel"
-          name="대한항공"
-          logo="koreanAir"
-          sharePrice={1100000}
-        />
-        <Cell
-          theme="elonMusk"
-          name="트위터"
-          logo="twitter"
-          sharePrice={1200000}
-        />
-      </Line2>
-      <Line3>
-        <Cell logo="goodNews" name="호재" />
-        <Cell
-          theme="pharmaceutical"
-          name="삼성바이오로직스"
-          logo="samsungBio"
-          sharePrice={1300000}
-        />
-        <Cell theme="it" name="구글" logo="google" sharePrice={1400000} />
-        <Cell logo="tax" name="세금" />
-        <Cell
-          theme="fashion"
-          name="에르메스"
-          logo="hermes"
-          sharePrice={1500000}
-        />
-        <Cell
-          theme="food"
-          name="맥도날드"
-          logo="mcdonalds"
-          sharePrice={1600000}
-        />
-      </Line3>
-      <Line4>
-        <Cell logo="rocket" name="순간이동" />
-        <Cell
-          theme="elonMusk"
-          name="테슬라"
-          logo="tesla"
-          sharePrice={1700000}
-        />
-        <Cell
-          theme="pharmaceutical"
-          name="화이자"
-          logo="pfizer"
-          sharePrice={1800000}
-        />
-        <Cell logo="goldCard" name="황금카드" />
-        <Cell
-          theme="military"
-          name="스타크 인더스트리"
-          logo="starkIndustry"
-          sharePrice={1900000}
-        />
-        <Cell theme="it" name="애플" logo="apple" sharePrice={2000000} />
-      </Line4>
-    </Board>
+    <>
+      <Board>
+        <Line1>
+          <Cell logo="start" name="start" />
+          <Cell
+            theme="it"
+            name="코드스쿼드"
+            logo="codesquad"
+            sharePrice={400000}
+          />
+          <Cell
+            theme="fashion"
+            name="무신사"
+            logo="musinsa"
+            sharePrice={500000}
+          />
+          <Cell
+            theme="travel"
+            name="하나투어"
+            logo="hanatour"
+            sharePrice={600000}
+          />
+          <Cell
+            theme="construction"
+            name="GS건설"
+            logo="gs"
+            sharePrice={700000}
+          />
+          <Cell theme="food" name="농심" logo="nongshim" sharePrice={800000} />
+        </Line1>
+        <Line2>
+          <Cell logo="jail" name="유치장" />
+          <Cell
+            theme="construction"
+            name="현대건설"
+            logo="hyundai"
+            sharePrice={900000}
+          />
+          <Cell
+            theme="military"
+            name="한화디펜스"
+            logo="hanwha"
+            sharePrice={1000000}
+          />
+          <Cell name="황금카드" logo="goldCard" />
+          <Cell
+            theme="travel"
+            name="대한항공"
+            logo="koreanAir"
+            sharePrice={1100000}
+          />
+          <Cell
+            theme="elonMusk"
+            name="트위터"
+            logo="twitter"
+            sharePrice={1200000}
+          />
+        </Line2>
+        <Line3>
+          <Cell logo="goodNews" name="호재" />
+          <Cell
+            theme="pharmaceutical"
+            name="삼성바이오로직스"
+            logo="samsungBio"
+            sharePrice={1300000}
+          />
+          <Cell theme="it" name="구글" logo="google" sharePrice={1400000} />
+          <Cell logo="tax" name="세금" />
+          <Cell
+            theme="fashion"
+            name="에르메스"
+            logo="hermes"
+            sharePrice={1500000}
+          />
+          <Cell
+            theme="food"
+            name="맥도날드"
+            logo="mcdonalds"
+            sharePrice={1600000}
+          />
+        </Line3>
+        <Line4>
+          <Cell logo="rocket" name="순간이동" />
+          <Cell
+            theme="elonMusk"
+            name="테슬라"
+            logo="tesla"
+            sharePrice={1700000}
+          />
+          <Cell
+            theme="pharmaceutical"
+            name="화이자"
+            logo="pfizer"
+            sharePrice={1800000}
+          />
+          <Cell logo="goldCard" name="황금카드" />
+          <Cell
+            theme="military"
+            name="스타크 인더스트리"
+            logo="starkIndustry"
+            sharePrice={1900000}
+          />
+          <Cell theme="it" name="애플" logo="apple" sharePrice={2000000} />
+        </Line4>
+        <Center>
+          <span>주사위 결과: {dice}</span>
+          <RollButton onClick={throwDice}>굴리기</RollButton>
+        </Center>
+        <PlayerToken ref={tokenRef} />
+      </Board>
+    </>
   );
 }
 
 const Board = styled.div`
   width: 42rem;
   height: 42rem;
-  margin: 0 auto;
   border-color: ${({ theme: { color } }) => color.accentText};
   position: relative;
 `;
@@ -162,4 +235,34 @@ const Line4 = styled.div`
   div {
     border-left: none;
   }
+`;
+
+const RollButton = styled.button`
+  width: 6rem;
+  height: 4rem;
+  background-color: grey;
+`;
+
+const Center = styled.div`
+  width: 30rem;
+  height: 30rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+  position: absolute;
+  top: 6rem;
+  left: 6rem;
+`;
+
+const PlayerToken = styled.div`
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  background-color: red;
+  position: absolute;
+  bottom: 1.5rem;
+  left: 1.5rem;
+
+  transition: all 0.2s;
 `;

--- a/fe/src/components/GameBoard/GameBoard.tsx
+++ b/fe/src/components/GameBoard/GameBoard.tsx
@@ -5,12 +5,17 @@ import {
   usePlayerToken3,
   usePlayerToken4,
 } from '@store/playerToken';
-import { changeDirection, delay } from '@utils/index';
+import { delay } from '@utils/index';
 import { RefObject, useRef, useState } from 'react';
 import { styled } from 'styled-components';
 import Cell from './Cell';
 import PlayerToken from './PlayerToken';
-import { CORNER_CELLS, TOKEN_TRANSITION_DELAY, directions } from './constants';
+import {
+  CORNER_CELLS,
+  TOKEN_TRANSITION_DELAY,
+  changeDirection,
+  directions,
+} from './constants';
 
 export default function GameBoard() {
   const [dice, setDice] = useState(0);
@@ -50,6 +55,17 @@ export default function GameBoard() {
     setDice(randomNum);
   };
 
+  const moveToNextCell = (
+    x: number,
+    y: number,
+    tokenRef: RefObject<HTMLDivElement>,
+    tokenAtom: PlayerTokenAtom
+  ) => {
+    tokenAtom.coordinates.x += x;
+    tokenAtom.coordinates.y += y;
+    tokenRef.current!.style.transform = `translate(${tokenAtom.coordinates.x}rem, ${tokenAtom.coordinates.y}rem)`;
+  };
+
   const moveToken = async (
     diceCount: number,
     tokenRef: RefObject<HTMLDivElement>,
@@ -62,15 +78,9 @@ export default function GameBoard() {
     let tokenDirection = tokenAtom.direction;
     let tokenLocation = tokenAtom.location;
 
-    const moveToNextCell = (x: number, y: number) => {
-      tokenCoordinates.x += x;
-      tokenCoordinates.y += y;
-      tokenRef.current!.style.transform = `translate(${tokenCoordinates.x}rem, ${tokenCoordinates.y}rem)`;
-    };
-
     for (let i = diceCount; i > 0; i--) {
       const directionData = directions[tokenDirection];
-      moveToNextCell(directionData.x, directionData.y);
+      moveToNextCell(directionData.x, directionData.y, tokenRef, tokenAtom);
 
       tokenLocation = (tokenLocation + 1) % 24;
       const isCorner = CORNER_CELLS.includes(tokenLocation); // 0, 6, 12, 18 칸에서 방향 전환

--- a/fe/src/components/GameBoard/PlayerToken.tsx
+++ b/fe/src/components/GameBoard/PlayerToken.tsx
@@ -1,5 +1,6 @@
 import { forwardRef } from 'react';
 import { styled } from 'styled-components';
+import { DefaultTheme } from 'styled-components/dist/types';
 
 type PlayerTokenProps = {
   order: number;
@@ -7,53 +8,27 @@ type PlayerTokenProps = {
 
 const PlayerToken = forwardRef<HTMLDivElement, PlayerTokenProps>(
   function PlayerToken({ order }, ref) {
-    switch (order) {
-      case 1:
-        return <Token1 ref={ref}>{order}</Token1>;
-      case 2:
-        return <Token2 ref={ref}>{order}</Token2>;
-      case 3:
-        return <Token3 ref={ref}>{order}</Token3>;
-      case 4:
-        return <Token4 ref={ref}>{order}</Token4>;
-    }
+    return (
+      <Token ref={ref} $order={order}>
+        {order}
+      </Token>
+    );
   }
 );
 
 export default PlayerToken;
 
-const Token = styled.div`
+const Token = styled.div<{ $order: number }>`
   width: 2rem;
   height: 2rem;
   position: absolute;
+  bottom: ${({ $order }) => ($order === 1 || $order === 2 ? 3 : 0.5)}rem;
+  left: ${({ $order }) => ($order === 2 || $order === 3 ? 3 : 0.5)}rem;
   display: flex;
   justify-content: center;
   align-items: center;
   border-radius: 50%;
+  background-color: ${({ theme, $order }) =>
+    theme.color[`player${$order}` as keyof DefaultTheme['color']]};
   transition: transform 0.2s;
-`;
-
-const Token1 = styled(Token)`
-  bottom: 3rem;
-  left: 0.5rem;
-  background-color: ${({ theme: { color } }) => color.player1};
-`;
-
-const Token2 = styled(Token)`
-  bottom: 3rem;
-  left: 3rem;
-  background-color: ${({ theme: { color } }) => color.player2};
-`;
-
-const Token3 = styled(Token)`
-  bottom: 0.5rem;
-  left: 3rem;
-  background-color: ${({ theme: { color } }) => color.player3};
-`;
-
-const Token4 = styled(Token)`
-  bottom: 0.5rem;
-  left: 0.5rem;
-  color: black;
-  background-color: ${({ theme: { color } }) => color.player4};
 `;

--- a/fe/src/components/GameBoard/PlayerToken.tsx
+++ b/fe/src/components/GameBoard/PlayerToken.tsx
@@ -1,0 +1,59 @@
+import { forwardRef } from 'react';
+import { styled } from 'styled-components';
+
+type PlayerTokenProps = {
+  order: number;
+};
+
+const PlayerToken = forwardRef<HTMLDivElement, PlayerTokenProps>(
+  function PlayerToken({ order }, ref) {
+    switch (order) {
+      case 1:
+        return <Token1 ref={ref}>{order}</Token1>;
+      case 2:
+        return <Token2 ref={ref}>{order}</Token2>;
+      case 3:
+        return <Token3 ref={ref}>{order}</Token3>;
+      case 4:
+        return <Token4 ref={ref}>{order}</Token4>;
+    }
+  }
+);
+
+export default PlayerToken;
+
+const Token = styled.div`
+  width: 2rem;
+  height: 2rem;
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%;
+  transition: transform 0.2s;
+`;
+
+const Token1 = styled(Token)`
+  bottom: 3rem;
+  left: 0.5rem;
+  background-color: ${({ theme: { color } }) => color.player1};
+`;
+
+const Token2 = styled(Token)`
+  bottom: 3rem;
+  left: 3rem;
+  background-color: ${({ theme: { color } }) => color.player2};
+`;
+
+const Token3 = styled(Token)`
+  bottom: 0.5rem;
+  left: 3rem;
+  background-color: ${({ theme: { color } }) => color.player3};
+`;
+
+const Token4 = styled(Token)`
+  bottom: 0.5rem;
+  left: 0.5rem;
+  color: black;
+  background-color: ${({ theme: { color } }) => color.player4};
+`;

--- a/fe/src/components/GameBoard/constants.ts
+++ b/fe/src/components/GameBoard/constants.ts
@@ -1,0 +1,8 @@
+export const CELL = {
+  WIDTH: 6,
+  HEIGHT: 6,
+};
+
+export const CORNER_CELLS = [0, 6, 12, 18];
+
+export const TOKEN_TRANSITION_DELAY = 200;

--- a/fe/src/components/GameBoard/constants.ts
+++ b/fe/src/components/GameBoard/constants.ts
@@ -5,4 +5,11 @@ export const CELL = {
 
 export const CORNER_CELLS = [0, 6, 12, 18];
 
+export const directions = {
+  top: { x: 0, y: -CELL.HEIGHT },
+  right: { x: CELL.WIDTH, y: 0 },
+  bottom: { x: 0, y: CELL.HEIGHT },
+  left: { x: -CELL.HEIGHT, y: 0 },
+};
+
 export const TOKEN_TRANSITION_DELAY = 200;

--- a/fe/src/components/GameBoard/constants.ts
+++ b/fe/src/components/GameBoard/constants.ts
@@ -1,3 +1,5 @@
+import { DirectionType } from '@store/playerToken';
+
 export const CELL = {
   WIDTH: 6,
   HEIGHT: 6,
@@ -13,3 +15,18 @@ export const directions = {
 };
 
 export const TOKEN_TRANSITION_DELAY = 200;
+
+export const changeDirection = (direction: DirectionType) => {
+  switch (direction) {
+    case 'top':
+      return 'right';
+    case 'right':
+      return 'bottom';
+    case 'bottom':
+      return 'left';
+    case 'left':
+      return 'top';
+    default:
+      return 'top';
+  }
+};

--- a/fe/src/store/playerToken/index.ts
+++ b/fe/src/store/playerToken/index.ts
@@ -1,5 +1,6 @@
-import { DirectionType } from '@components/GameBoard/GameBoard';
 import { atom, useAtom } from 'jotai';
+
+export type DirectionType = 'top' | 'right' | 'bottom' | 'left';
 
 export type PlayerTokenAtom = {
   location: number;

--- a/fe/src/store/playerToken/index.ts
+++ b/fe/src/store/playerToken/index.ts
@@ -1,0 +1,37 @@
+import { DirectionType } from '@components/GameBoard/GameBoard';
+import { atom, useAtom } from 'jotai';
+
+export type PlayerTokenAtom = {
+  location: number;
+  direction: DirectionType;
+  coordinates: { x: number; y: number };
+};
+
+const playerToken1 = atom<PlayerTokenAtom>({
+  location: 0,
+  direction: 'top',
+  coordinates: { x: 0, y: 0 },
+});
+
+const playerToken2 = atom<PlayerTokenAtom>({
+  location: 0,
+  direction: 'top',
+  coordinates: { x: 0, y: 0 },
+});
+
+const playerToken3 = atom<PlayerTokenAtom>({
+  location: 0,
+  direction: 'top',
+  coordinates: { x: 0, y: 0 },
+});
+
+const playerToken4 = atom<PlayerTokenAtom>({
+  location: 0,
+  direction: 'top',
+  coordinates: { x: 0, y: 0 },
+});
+
+export const usePlayerToken1 = () => useAtom<PlayerTokenAtom>(playerToken1);
+export const usePlayerToken2 = () => useAtom<PlayerTokenAtom>(playerToken2);
+export const usePlayerToken3 = () => useAtom<PlayerTokenAtom>(playerToken3);
+export const usePlayerToken4 = () => useAtom<PlayerTokenAtom>(playerToken4);

--- a/fe/src/styles/designSystem.ts
+++ b/fe/src/styles/designSystem.ts
@@ -3,9 +3,11 @@ import type { DefaultTheme } from 'styled-components';
 export const colors = {
   white: '#FFF',
   black: '#000',
+  blue: '#007AFF',
   royalBlue: '#4169E1',
   purple: '#823FE8',
   red: '#FF3B30',
+  yellow: '#FFCC00',
   greyWithBlur: '#00000033',
   grey10: '#E5E5E5',
   grey20: '#CCC',
@@ -62,6 +64,11 @@ export const designSystem = {
     systemWarning: colors.red,
     systemBackground: colors.white,
     systemBackgroundWeak: colors.grey10,
+
+    player1: colors.black,
+    player2: colors.red,
+    player3: colors.blue,
+    player4: colors.yellow,
   },
   filter: {
     neutralText:

--- a/fe/src/utils/index.ts
+++ b/fe/src/utils/index.ts
@@ -1,0 +1,3 @@
+export function delay(time: number) {
+  return new Promise((resolve) => setTimeout(resolve, time));
+}

--- a/fe/src/utils/index.ts
+++ b/fe/src/utils/index.ts
@@ -1,3 +1,20 @@
+import { DirectionType } from '@store/playerToken';
+
 export function delay(time: number) {
   return new Promise((resolve) => setTimeout(resolve, time));
 }
+
+export const changeDirection = (direction: DirectionType) => {
+  switch (direction) {
+    case 'top':
+      return 'right';
+    case 'right':
+      return 'bottom';
+    case 'bottom':
+      return 'left';
+    case 'left':
+      return 'top';
+    default:
+      return 'top';
+  }
+};

--- a/fe/src/utils/index.ts
+++ b/fe/src/utils/index.ts
@@ -1,20 +1,3 @@
-import { DirectionType } from '@store/playerToken';
-
 export function delay(time: number) {
   return new Promise((resolve) => setTimeout(resolve, time));
 }
-
-export const changeDirection = (direction: DirectionType) => {
-  switch (direction) {
-    case 'top':
-      return 'right';
-    case 'right':
-      return 'bottom';
-    case 'bottom':
-      return 'left';
-    case 'left':
-      return 'top';
-    default:
-      return 'top';
-  }
-};

--- a/fe/tsconfig.json
+++ b/fe/tsconfig.json
@@ -31,7 +31,8 @@
       "@hooks/*": ["hooks/*"],
       "@styles/*": ["styles/*"],
       "@mocks/*": ["mocks/*"],
-      "@store/*": ["store/*"]
+      "@store/*": ["store/*"],
+      "@utils/*": ["utils/*"]
     },
 
     "esModuleInterop": true


### PR DESCRIPTION
## 📌 이슈번호
- #25 

## 🔑 Key changes
https://github.com/codesquad-members-2023/gaemi-marble-team-04/assets/76121068/4113064f-7356-4298-be37-bb644b8ed0fa

### PlayerToken 컴포넌트 구현
 플레이어 말을 `PlayerToken`이라는 이름의 컴포넌트로 구현했습니다. 우선 간단히 `order`를 props로 받아 플레이어 입장순서에 맞는 색상과 시작위치를 가지도록 구현했습니다. 실제 플레이 시에는 플레이어가 입장해야 토큰이 렌더링 되야하는데 이건 우선 웹소켓 연결 후 오는 응답으로 작업해야 할 것 같아서 여기서는 구현하지 않았습니다.
### 플레이어 토큰 이동 기능
 플레이어 토큰을 게임판에서 이동시킬 때 사용할 `moveToken(diceCount, tokenRef, tokenAtom, setTokenAtom)` 함수를 구현하였습니다. 첫번째 인자인 `diceCount`에 두 주사위를 굴려 나온 눈 수의 합을 받고, 두번째 인자로는 이동시킬 플레이어 토큰의 `ref`를 받아서 사용합니다. 그리고 3, 4번째 인자로는 usePlayerToken 훅이 반환하는 각 플레이어별 tokenAtom과 setTokenAtom을 넘겨줍니다.
  - 우선 기본적인 로직의 흐름은 이러합니다.
    1) 기본적으로 모든 토큰들은 현재 위치한 Cell의 인덱스(location), 자신이 향하는 방향(direction), 게임판 속 위치좌표(coordinates)를 가지고 있습니다.
    2) 나온 주사위의 눈 수 만큼 for문을 반복하며 현재 direction에 맞는 방향으로 한칸씩 전진합니다.
    3) 한칸씩 전진하다가 location이 모서리칸 (0, 6, 12, 18)일 때는 direction을 바꿉니다. 위 -> 오른쪽 -> 아래 -> 왼쪽 으로 진행방향이 반복되는 순서라 우선 utils에 `changeDirection()`이라는 간단한 함수로 빼두었습니다.
    4) 이후 direction이 바뀐 이후에도 남은 주사위 눈 만큼 마저 전진합니다.
    5) 마지막으로 playerTokenAtom의 상태를 최종 토큰 위치로 업데이트 해준후 끝납니다.

나머지 부분들은 아마 주사위 기능 작업하면서 조금씩 수정될 수도 있을것 같습니다. 이동하는 로직부분이랑 atom 사용한 부분 위주로 봐주시면 감사하겠습니다. 🙇‍♂️

## 👋 To reviewers
- throwDice() 함수는 각 플레이어의 말들이 잘 움직이는지 확인하기 위해 구현한 함수로 추후 삭제될 예정입니다.
- desingSystem에 플레이어 별 테마 색상을 추가하였습니다.
- 각 플레이어의 토큰 상태를 저장하는 atom은 사실 플레이어가 입장했을 때 그 수에 맞게 만들어져야 하는데 이걸 어떻게 구현해야할지 우선 감이 안잡혀서 우선은 1~4 번 플레이어 모두 우선 만들어둔 상태입니다.
