### PR TITLE
[BE] 요구사항 반영 (이벤트결정, 전체현황판, 개인현황판, 게임입장, 로그아웃)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+﻿be/src/main/resources/application-secret.yml

--- a/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
@@ -22,6 +22,7 @@ import codesquad.gaemimarble.game.dto.request.GameSellStockRequest;
 import codesquad.gaemimarble.game.dto.request.GameStartRequest;
 import codesquad.gaemimarble.game.dto.request.GameStockBuyRequest;
 import codesquad.gaemimarble.game.dto.response.GameAccessibleResponse;
+import codesquad.gaemimarble.game.dto.response.GameEventNameResponse;
 import codesquad.gaemimarble.game.dto.response.GameReadyResponse;
 import codesquad.gaemimarble.game.dto.response.GameRoomCreateResponse;
 import codesquad.gaemimarble.game.entity.TypeConstants;
@@ -69,8 +70,11 @@ public class GameController {
 	}
 
 	private void sendEventResult(GameEventResultRequest gameEventResultRequest) {
+		GameEventNameResponse gameEventNameResponse = gameService.selectEvent(gameEventResultRequest);
+		socketDataSender.send(gameEventResultRequest.getGameId(), new ResponseDTO<>(TypeConstants.EVENTS_RESULT,
+			gameEventNameResponse));
 		socketDataSender.send(gameEventResultRequest.getGameId(), new ResponseDTO<>(TypeConstants.STATUS_BOARD,
-			gameService.proceedEvent(gameEventResultRequest)));
+			gameService.proceedEvent(gameEventNameResponse.getName(), gameEventResultRequest.getGameId())));
 	}
 
 	@PostMapping("/api/games")
@@ -105,9 +109,7 @@ public class GameController {
 
 	private void sendReadyStatus(GameReadyRequest gameReadyRequest) {
 		socketDataSender.send(gameReadyRequest.getGameId(), new ResponseDTO<>(TypeConstants.READY,
-			GameReadyResponse.builder()
-				.isReady(gameReadyRequest.getIsReady())
-				.playerId(gameReadyRequest.getPlayerId()).build()));
+			gameService.readyGame(gameReadyRequest)));
 	}
 
 	private void sendFirstPlayer(GameStartRequest gameStartRequest) {

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/GameMapper.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/GameMapper.java
@@ -8,7 +8,7 @@ import org.mapstruct.factory.Mappers;
 
 import codesquad.gaemimarble.game.dto.response.generalStatusBoard.GameStockStatusResponse;
 import codesquad.gaemimarble.game.dto.response.userStatusBoard.GameUserStatusBoardResponse;
-import codesquad.gaemimarble.game.dto.response.userStatusBoard.StockNameResponse;
+import codesquad.gaemimarble.game.dto.response.userStatusBoard.StockResponse;
 import codesquad.gaemimarble.game.entity.Player;
 import codesquad.gaemimarble.game.entity.Stock;
 
@@ -22,7 +22,7 @@ public interface GameMapper {
 	GameStockStatusResponse toGameStockStatusResponse(Stock stock, String themeName);
 
 	@Mapping(target = "stockList", source = "stockList")
-	GameUserStatusBoardResponse toGameUserStatusBoardResponse(Player player, List<StockNameResponse> stockList);
+	GameUserStatusBoardResponse toGameUserStatusBoardResponse(Player player, List<StockResponse> stockList);
 
-	StockNameResponse toStockNameResponse(String name);
+	StockResponse toStockResponse(String name, Integer quantity);
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/request/GameEventResultRequest.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/request/GameEventResultRequest.java
@@ -1,5 +1,7 @@
 package codesquad.gaemimarble.game.dto.request;
 
+import java.util.List;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,11 +10,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class GameEventResultRequest {
 	private Long gameId;
-	private String eventName;
+	private List<String> events;
 
 	@Builder
-	private GameEventResultRequest(Long gameId, String eventName) {
+	private GameEventResultRequest(Long gameId, List<String> events) {
 		this.gameId = gameId;
-		this.eventName = eventName;
+		this.events = events;
 	}
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/response/GameEnterResponse.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/response/GameEnterResponse.java
@@ -9,17 +9,20 @@ import lombok.NoArgsConstructor;
 public class GameEnterResponse {
 	private Integer order;
 	private String playerId;
+	private Boolean isReady;
 
 	@Builder
-	public GameEnterResponse(Integer order, String playerId) {
+	public GameEnterResponse(Integer order, String playerId, Boolean isReady) {
 		this.order = order;
 		this.playerId = playerId;
+		this.isReady = isReady;
 	}
 
-	public static GameEnterResponse of(Integer order, String playerId) {
+	public static GameEnterResponse of(Integer order, String playerId, Boolean isReady) {
 		return GameEnterResponse.builder()
 			.order(order)
 			.playerId(playerId)
+			.isReady(isReady)
 			.build();
 	}
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/response/GameEventNameResponse.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/response/GameEventNameResponse.java
@@ -1,0 +1,14 @@
+package codesquad.gaemimarble.game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class GameEventNameResponse {
+	private final String name;
+
+	@Builder
+	private GameEventNameResponse(String name) {
+		this.name = name;
+	}
+}

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/response/userStatusBoard/GameUserStatusBoardResponse.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/response/userStatusBoard/GameUserStatusBoardResponse.java
@@ -10,11 +10,11 @@ public class GameUserStatusBoardResponse {
 	private final Integer cashAsset;
 	private final Integer stockAsset;
 	private final Integer totalAsset;
-	List<StockNameResponse> stockList;
+	List<StockResponse> stockList;
 
 	@Builder
 	public GameUserStatusBoardResponse(Integer cashAsset, Integer stockAsset, Integer totalAsset,
-		List<StockNameResponse> stockList) {
+		List<StockResponse> stockList) {
 		this.cashAsset = cashAsset;
 		this.stockAsset = stockAsset;
 		this.totalAsset = totalAsset;

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/response/userStatusBoard/StockResponse.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/response/userStatusBoard/StockResponse.java
@@ -4,11 +4,13 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class StockNameResponse {
+public class StockResponse {
 	private final String name;
+	private final Integer quantity;
 
 	@Builder
-	private StockNameResponse(String name) {
+	private StockResponse(String name, Integer quantity) {
 		this.name = name;
+		this.quantity = quantity;
 	}
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/entity/Player.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/entity/Player.java
@@ -16,11 +16,12 @@ public class Player {
 	private Integer stockAsset;
 	private Integer cashAsset;
 	private Integer totalAsset;
+	private Boolean isReady;
 	// 상태, 황금카드 보류
 
 	@Builder
 	Player(String playerId, Integer order, Integer location, Map<String, Integer> myStocks, Integer stockAsset,
-		Integer cashAsset, Integer totalAsset) {
+		Integer cashAsset, Integer totalAsset, Boolean isReady) {
 		this.playerId = playerId;
 		this.order = order;
 		this.location = location;
@@ -28,6 +29,7 @@ public class Player {
 		this.stockAsset = stockAsset;
 		this.cashAsset = cashAsset;
 		this.totalAsset = totalAsset;
+		this.isReady = isReady;
 	}
 
 	public static Player init(String playerId) {
@@ -38,6 +40,7 @@ public class Player {
 			.myStocks(new HashMap<>())
 			.stockAsset(0)
 			.totalAsset(200_000_000)
+			.isReady(false)
 			.build();
 	}
 
@@ -49,14 +52,14 @@ public class Player {
 		this.location = location;
 	}
 
-	public void setAsset(int cashAsset, int stockAsset) {
+	public void addAsset(int cashAsset, int stockAsset) {
 		this.cashAsset += cashAsset;
 		this.stockAsset += stockAsset;
 		this.totalAsset = this.cashAsset + this.stockAsset;
 	}
 
-	public GameEnterResponse toDto() {
-		return new GameEnterResponse(this.getOrder(), this.getPlayerId());
+	public void setReady(boolean isReady) {
+		this.isReady = isReady;
 	}
 
 	public void move(int i) {
@@ -77,5 +80,10 @@ public class Player {
 		myStocks.put(stock.getName(), myStocks.get(stock.getName()) - quantity);
 		cashAsset += quantity * stock.getCurrentPrice();
 		stockAsset -= quantity * stock.getCurrentPrice();
+	}
+
+	public void updateStockAsset(Stock stock) {
+		stockAsset = myStocks.get(stock.getName()) * stock.getCurrentPrice();
+		totalAsset = cashAsset + stockAsset;
 	}
 }

--- a/be/src/main/java/codesquad/gaemimarble/user/controller/UserController.java
+++ b/be/src/main/java/codesquad/gaemimarble/user/controller/UserController.java
@@ -44,13 +44,13 @@ public class UserController {
 		return ResponseEntity.ok(Map.of(Constants.PLAYER_ID, userLoginRequest.getPlayerId()));
 	}
 
-	@GetMapping("/reissue-access-token")
+	@GetMapping("/api/reissue-access-token")
 	public Jwt reissueToken(@RequestBody JwtRefreshTokenRequest jwtRefreshTokenRequest, HttpServletRequest request) {
 		return jwtService.reissueAccessToken(
 			jwtRefreshTokenRequest.getRefreshToken(), (String)request.getAttribute(Constants.PLAYER_ID));
 	}
 
-	@PostMapping("/logout")
+	@PostMapping("/api/logout")
 	public ResponseEntity<Void> logout(HttpServletRequest request) {
 		String accessToken = request.getHeader(HttpHeaders.AUTHORIZATION).substring(
 			Constants.TOKEN_PREFIX.length()).replace("\"", "");


### PR DESCRIPTION
## 📌 이슈번호
- #43 

## 🔑 Key changes
-  이벤트 결정 요청 시, 랜덤 이벤트 선정하여 추가 메시지 전송
→ 즉, 6개 이벤트 중 랜덤하게 선택된 이벤트 결과와 전체 현황판 각각 Response
- dto 이름 수정 (StockNameResponse → StockResponse)
- 전체 현황판 업데이트 시, 플레이어 보유 자산 반영 (GameStatus)
- 개인 현황판 응답 시, 주식 수량 추가
- 게임 입장 응답 시, 준비 상태 추가
→ 게임 준비 요청 시, 준비 상태 저장
- 로그아웃 url 수정

## 👋 To reviewers
- 정상 작동 확인했습니다.

---
Pair programming with @yhpark95  via CodeWithMe