### PR TITLE
[BE] 감옥, 세금 구현 및 오류 수정, 추가 요청 처리 등

### DIFF
--- a/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
@@ -22,7 +22,9 @@ import codesquad.gaemimarble.game.dto.request.GameSellStockRequest;
 import codesquad.gaemimarble.game.dto.request.GameStartRequest;
 import codesquad.gaemimarble.game.dto.request.GameStockBuyRequest;
 import codesquad.gaemimarble.game.dto.response.GameAccessibleResponse;
+import codesquad.gaemimarble.game.dto.response.GameCellResponse;
 import codesquad.gaemimarble.game.dto.response.GameEventNameResponse;
+import codesquad.gaemimarble.game.dto.response.GameExpenseResponse;
 import codesquad.gaemimarble.game.dto.response.GameReadyResponse;
 import codesquad.gaemimarble.game.dto.response.GameRoomCreateResponse;
 import codesquad.gaemimarble.game.entity.TypeConstants;
@@ -121,8 +123,10 @@ public class GameController {
 	private void sendDiceResult(GameRollDiceRequest gameRollDiceRequest) {
 		socketDataSender.send(gameRollDiceRequest.getGameId(), new ResponseDTO<>(TypeConstants.DICE,
 			gameService.rollDice(gameRollDiceRequest)));
+		GameCellResponse gameCellResponse = gameService.arriveAtCell(gameRollDiceRequest);
 		socketDataSender.send(gameRollDiceRequest.getGameId(), new ResponseDTO<>(TypeConstants.CELL,
-			gameService.arriveAtCell(gameRollDiceRequest)));
+			gameCellResponse));
+		actCell(gameRollDiceRequest.getGameId(), gameCellResponse);
 	}
 
 	private void sendRandomEvents(GameEventRequest gameEventRequest) {
@@ -133,5 +137,21 @@ public class GameController {
 	private void sendBuyResult(GameStockBuyRequest gameStockBuyRequest) {
 		socketDataSender.send(gameStockBuyRequest.getGameId(), new ResponseDTO<>(TypeConstants.BUY,
 			gameService.buyStock(gameStockBuyRequest)));
+	}
+
+	private void actCell(Long gameId, GameCellResponse gameCellResponse) {
+		switch (gameCellResponse.getLocation()) {
+			// case 9: // 황금카드
+			// case 12: // 호재
+			case 15: // 세금
+				socketDataSender.send(gameId, new ResponseDTO<>(TypeConstants.EXPENSE,
+					GameExpenseResponse.builder()
+					.playerId(gameCellResponse.getPlayerId())
+					.amount(5000000)
+					.build()));
+				break;
+			//case 21: // 황금카드
+			// default: // 기업
+		}
 	}
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
@@ -92,7 +92,7 @@ public class GameController {
 	}
 
 	public void enterGame(Long gameId, WebSocketSession session, String playerId) {
-		socketDataSender.saveSocket(gameId, session);
+		socketDataSender.saveSocket(gameId, playerId, session);
 		socketDataSender.send(gameId, new ResponseDTO<>(TypeConstants.ENTER, gameService.enterGame(gameId, playerId)));
 	}
 

--- a/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
@@ -25,7 +25,6 @@ import codesquad.gaemimarble.game.dto.response.GameAccessibleResponse;
 import codesquad.gaemimarble.game.dto.response.GameCellResponse;
 import codesquad.gaemimarble.game.dto.response.GameEventNameResponse;
 import codesquad.gaemimarble.game.dto.response.GameExpenseResponse;
-import codesquad.gaemimarble.game.dto.response.GameReadyResponse;
 import codesquad.gaemimarble.game.dto.response.GameRoomCreateResponse;
 import codesquad.gaemimarble.game.entity.TypeConstants;
 import codesquad.gaemimarble.game.service.GameService;
@@ -145,10 +144,7 @@ public class GameController {
 			// case 12: // 호재
 			case 15: // 세금
 				socketDataSender.send(gameId, new ResponseDTO<>(TypeConstants.EXPENSE,
-					GameExpenseResponse.builder()
-					.playerId(gameCellResponse.getPlayerId())
-					.amount(5000000)
-					.build()));
+					gameService.payExpense(gameId, gameCellResponse.getPlayerId(), 10_000_000)));
 				break;
 			//case 21: // 황금카드
 			// default: // 기업

--- a/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
@@ -119,10 +119,13 @@ public class GameController {
 			gameService.readyGame(gameReadyRequest)));
 	}
 
+	// 게임 시작
 	private void sendFirstPlayer(GameStartRequest gameStartRequest) {
 		String playerId = gameService.getFirstPlayer(gameStartRequest.getGameId());
 		socketDataSender.send(gameStartRequest.getGameId(), new ResponseDTO<>(TypeConstants.START,
 			Map.of("playerId", playerId)));
+		socketDataSender.send(gameStartRequest.getGameId(), new ResponseDTO<>(TypeConstants.STATUS_BOARD,
+			gameService.createGameStatusBoardResponse(gameStartRequest.getGameId())));
 	}
 
 	private void sendDiceResult(GameRollDiceRequest gameRollDiceRequest) {

--- a/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
@@ -16,6 +16,7 @@ import codesquad.gaemimarble.game.dto.ResponseDTO;
 import codesquad.gaemimarble.game.dto.request.GameEndTurnRequest;
 import codesquad.gaemimarble.game.dto.request.GameEventRequest;
 import codesquad.gaemimarble.game.dto.request.GameEventResultRequest;
+import codesquad.gaemimarble.game.dto.request.GamePrisonDiceRequest;
 import codesquad.gaemimarble.game.dto.request.GameReadyRequest;
 import codesquad.gaemimarble.game.dto.request.GameRollDiceRequest;
 import codesquad.gaemimarble.game.dto.request.GameSellStockRequest;
@@ -48,6 +49,7 @@ public class GameController {
 		typeMap.put(TypeConstants.BUY, GameStockBuyRequest.class);
 		typeMap.put(TypeConstants.SELL, GameSellStockRequest.class);
 		typeMap.put(TypeConstants.END_TURN, GameEndTurnRequest.class);
+		typeMap.put(TypeConstants.PRISON_DICE, GamePrisonDiceRequest.class);
 
 		this.handlers = new HashMap<>();
 		handlers.put(GameReadyRequest.class, req -> sendReadyStatus((GameReadyRequest)req));
@@ -58,6 +60,7 @@ public class GameController {
 		handlers.put(GameStockBuyRequest.class, req -> sendBuyResult((GameStockBuyRequest)req));
 		handlers.put(GameSellStockRequest.class, req -> sendSellResult((GameSellStockRequest)req));
 		handlers.put(GameEndTurnRequest.class, req -> sendNextPlayer((GameEndTurnRequest)req));
+		handlers.put(GamePrisonDiceRequest.class, req -> sendPrisonDiceResult((GamePrisonDiceRequest)req));
 	}
 
 	private void sendNextPlayer(GameEndTurnRequest gameEndTurnRequest) {
@@ -136,6 +139,11 @@ public class GameController {
 	private void sendBuyResult(GameStockBuyRequest gameStockBuyRequest) {
 		socketDataSender.send(gameStockBuyRequest.getGameId(), new ResponseDTO<>(TypeConstants.BUY,
 			gameService.buyStock(gameStockBuyRequest)));
+	}
+
+	public void sendPrisonDiceResult(GamePrisonDiceRequest gamePrisonDiceRequest) {
+		socketDataSender.send(gamePrisonDiceRequest.getGameId(), new ResponseDTO<>(TypeConstants.PRISON_DICE,
+			gameService.prisonDice(gamePrisonDiceRequest)));
 	}
 
 	private void actCell(Long gameId, GameCellResponse gameCellResponse) {

--- a/be/src/main/java/codesquad/gaemimarble/game/controller/SocketDataSender.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/controller/SocketDataSender.java
@@ -26,8 +26,18 @@ public class SocketDataSender {
 		gameSocketMap.put(gameRoomId, new HashSet<>());
 	}
 
-	public void saveSocket(Long gameId, WebSocketSession session) {
-		gameSocketMap.get(gameId).add(session);
+	public void saveSocket(Long gameId, String playerId, WebSocketSession session) {
+		Set<WebSocketSession> sessions = gameSocketMap.computeIfAbsent(gameId, key -> ConcurrentHashMap.newKeySet());
+
+		boolean isDuplicate = sessions.stream()
+			.anyMatch(s -> s.getAttributes().get("playerId").equals(playerId));
+
+		if (!isDuplicate) {
+			session.getAttributes().put("playerId", playerId);
+			sessions.add(session);
+		} else {
+			throw new RuntimeException("이미 입장한 유저입니다.");
+		}
 	}
 
 	public <T> void send(Long gameId, T object) {

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/request/GameBailRequest.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/request/GameBailRequest.java
@@ -1,0 +1,16 @@
+package codesquad.gaemimarble.game.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class GameBailRequest {
+	Long gameId;
+	String playerId;
+
+	@Builder
+	public GameBailRequest(Long gameId, String playerId) {
+		this.gameId = gameId;
+		this.playerId = playerId;
+	}
+}

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/request/GamePrisonDiceRequest.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/request/GamePrisonDiceRequest.java
@@ -1,0 +1,16 @@
+package codesquad.gaemimarble.game.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class GamePrisonDiceRequest {
+	private Long gameId;
+	private String playerId;
+
+	@Builder
+	public GamePrisonDiceRequest(Long gameId, String playerId) {
+		this.gameId = gameId;
+		this.playerId = playerId;
+	}
+}

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/response/GameExpenseResponse.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/response/GameExpenseResponse.java
@@ -1,0 +1,16 @@
+package codesquad.gaemimarble.game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class GameExpenseResponse {
+	String playerId;
+	Integer amount;
+
+	@Builder
+	private GameExpenseResponse(String playerId, Integer amount) {
+		this.playerId = playerId;
+		this.amount = amount;
+	}
+}

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/response/GamePrisonDiceResponse.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/response/GamePrisonDiceResponse.java
@@ -1,0 +1,18 @@
+package codesquad.gaemimarble.game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class GamePrisonDiceResponse {
+	private Integer dice1;
+	private Integer dice2;
+	private Boolean hasEscaped;
+
+	@Builder
+	private GamePrisonDiceResponse(Integer dice1, Integer dice2, Boolean hasEscaped) {
+		this.dice1 = dice1;
+		this.dice2 = dice2;
+		this.hasEscaped = hasEscaped;
+	}
+}

--- a/be/src/main/java/codesquad/gaemimarble/game/entity/Events.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/entity/Events.java
@@ -43,7 +43,7 @@ public enum Events {
 		Map.of(Theme.FASHION, 30)),
 	KOREAN_AIR_STRIKE("대한항공, 하나투어 파업", "20일 동안 대규모 파업", "여행 - 20%",
 		Map.of(Theme.TRIP, -20)),
-	SUCCESSFUL_MCDONALDS_COLLAB("성공적인 맥도날드, 농심 콜라보", "신제품 버거 출시", "식품산업 + 30%",
+	SUCCESSFUL_MCDONALDS_COLLAB("맥도날드x농심 콜라보!", "신제품 버거 출시", "식품산업 + 30%",
 		Map.of(Theme.FOOD, 30));
 
 	private final String title;

--- a/be/src/main/java/codesquad/gaemimarble/game/entity/Player.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/entity/Player.java
@@ -17,11 +17,12 @@ public class Player {
 	private Integer cashAsset;
 	private Integer totalAsset;
 	private Boolean isReady;
+	private Integer prisonCount;
 	// 상태, 황금카드 보류
 
 	@Builder
 	Player(String playerId, Integer order, Integer location, Map<String, Integer> myStocks, Integer stockAsset,
-		Integer cashAsset, Integer totalAsset, Boolean isReady) {
+		Integer cashAsset, Integer totalAsset, Boolean isReady, Integer prisonCount) {
 		this.playerId = playerId;
 		this.order = order;
 		this.location = location;
@@ -30,6 +31,7 @@ public class Player {
 		this.cashAsset = cashAsset;
 		this.totalAsset = totalAsset;
 		this.isReady = isReady;
+		this.prisonCount = prisonCount;
 	}
 
 	public static Player init(String playerId) {
@@ -41,6 +43,7 @@ public class Player {
 			.stockAsset(0)
 			.totalAsset(200_000_000)
 			.isReady(false)
+			.prisonCount(0)
 			.build();
 	}
 
@@ -85,5 +88,14 @@ public class Player {
 	public void updateStockAsset(Stock stock) {
 		stockAsset = myStocks.get(stock.getName()) * stock.getCurrentPrice();
 		totalAsset = cashAsset + stockAsset;
+	}
+
+	public void escapePrison(int diceResult) {
+		this.prisonCount = 0;
+		this.location += diceResult;
+	}
+
+	public void increasePrisonCount() {
+		this.prisonCount += 1;
 	}
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/entity/TypeConstants.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/entity/TypeConstants.java
@@ -14,4 +14,5 @@ public final class TypeConstants {
 	public static final String END_TURN = "endTurn";
 	public static final String EXPENSE = "expense";
 	public static final String PRISON_DICE = "prisonDice";
+	public static final String BAIL = "bail";
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/entity/TypeConstants.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/entity/TypeConstants.java
@@ -12,4 +12,5 @@ public final class TypeConstants {
 	public static final String BUY = "buy";
 	public static final String SELL = "sell";
 	public static final String END_TURN = "endTurn";
+	public static final String EXPENSE = "expense";
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/entity/TypeConstants.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/entity/TypeConstants.java
@@ -13,4 +13,5 @@ public final class TypeConstants {
 	public static final String SELL = "sell";
 	public static final String END_TURN = "endTurn";
 	public static final String EXPENSE = "expense";
+	public static final String PRISON_DICE = "prisonDice";
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
@@ -25,6 +25,7 @@ import codesquad.gaemimarble.game.dto.response.GameEnterResponse;
 import codesquad.gaemimarble.game.dto.response.GameEventListResponse;
 import codesquad.gaemimarble.game.dto.response.GameEventNameResponse;
 import codesquad.gaemimarble.game.dto.response.GameEventResponse;
+import codesquad.gaemimarble.game.dto.response.GameExpenseResponse;
 import codesquad.gaemimarble.game.dto.response.GameReadyResponse;
 import codesquad.gaemimarble.game.dto.response.GameRoomCreateResponse;
 import codesquad.gaemimarble.game.dto.response.generalStatusBoard.GameStatusBoardResponse;
@@ -136,6 +137,15 @@ public class GameService {
 			.location(player.getLocation())
 			.salary(salary)
 			.dividend(dividend)
+			.build();
+	}
+
+	public GameExpenseResponse payExpense(Long gameId, String playerId, int expense) {
+		Player player = gameRepository.getGameStatus(gameId).getPlayer(playerId);
+		player.addAsset(expense, 0);
+		return GameExpenseResponse.builder()
+			.playerId(player.getPlayerId())
+			.amount(expense)
 			.build();
 	}
 

--- a/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import codesquad.gaemimarble.game.dto.GameMapper;
 import codesquad.gaemimarble.game.dto.request.GameEndTurnRequest;
 import codesquad.gaemimarble.game.dto.request.GameEventResultRequest;
+import codesquad.gaemimarble.game.dto.request.GamePrisonDiceRequest;
 import codesquad.gaemimarble.game.dto.request.GameReadyRequest;
 import codesquad.gaemimarble.game.dto.request.GameRollDiceRequest;
 import codesquad.gaemimarble.game.dto.request.GameSellStockRequest;
@@ -26,6 +27,7 @@ import codesquad.gaemimarble.game.dto.response.GameEventListResponse;
 import codesquad.gaemimarble.game.dto.response.GameEventNameResponse;
 import codesquad.gaemimarble.game.dto.response.GameEventResponse;
 import codesquad.gaemimarble.game.dto.response.GameExpenseResponse;
+import codesquad.gaemimarble.game.dto.response.GamePrisonDiceResponse;
 import codesquad.gaemimarble.game.dto.response.GameReadyResponse;
 import codesquad.gaemimarble.game.dto.response.GameRoomCreateResponse;
 import codesquad.gaemimarble.game.dto.response.generalStatusBoard.GameStatusBoardResponse;
@@ -320,6 +322,29 @@ public class GameService {
 		}
 		return GameEndTurnResponse.builder()
 			.nextPlayerId(null)
+			.build();
+	}
+
+	public GamePrisonDiceResponse prisonDice(GamePrisonDiceRequest gamePrisonDiceRequest) {
+		GameStatus gameStatus = gameRepository.getGameStatus(gamePrisonDiceRequest.getGameId());
+		Player player = gameStatus.getPlayer(gamePrisonDiceRequest.getPlayerId());
+
+		int dice1 = (int)(Math.random() * 6) + 1;
+		int dice2 = (int)(Math.random() * 6) + 1;
+
+		if (dice1 == dice2) {
+			player.escapePrison(dice1 + dice2);
+		} else {
+			player.increasePrisonCount();
+			if (player.getPrisonCount() == 3) {
+				player.escapePrison(dice1 + dice2);
+			}
+		}
+
+		return GamePrisonDiceResponse.builder()
+			.dice1(dice1)
+			.dice2(dice2)
+			.hasEscaped(player.getPrisonCount() == 0)
 			.build();
 	}
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
@@ -144,7 +144,7 @@ public class GameService {
 
 	public GameExpenseResponse payExpense(Long gameId, String playerId, int expense) {
 		Player player = gameRepository.getGameStatus(gameId).getPlayer(playerId);
-		player.addAsset(expense, 0);
+		player.addAsset(-expense, 0);
 		return GameExpenseResponse.builder()
 			.playerId(player.getPlayerId())
 			.amount(expense)

--- a/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
@@ -101,9 +101,9 @@ public class GameService {
 		return GameAccessibleResponse.builder().isPresent(isPresent).isFull(isFull).build();
 	}
 
-	public GameDiceResult rollDice(GameRollDiceRequest gameRollDiceRequest) {
-		GameStatus gameStatus = gameRepository.getGameStatus(gameRollDiceRequest.getGameId());
-		Player player = gameStatus.getPlayer(gameRollDiceRequest.getPlayerId());
+	public GameDiceResult rollDice(Long gameId, String playerId) {
+		GameStatus gameStatus = gameRepository.getGameStatus(gameId);
+		Player player = gameStatus.getPlayer(playerId);
 		int startLocation = player.getLocation();
 
 		int dice1 = (int)(Math.random() * 6) + 1;

--- a/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
@@ -67,7 +67,7 @@ public class GameService {
 
 	public GameReadyResponse readyGame(GameReadyRequest gameReadyRequest) {
 		Player player = gameRepository.getGameStatus(gameReadyRequest.getGameId()).getPlayer(gameReadyRequest.getPlayerId());
-		player.setReady(true);
+		player.setReady(gameReadyRequest.getIsReady());
 		return GameReadyResponse.builder()
 			.playerId(player.getPlayerId())
 			.isReady(player.getIsReady())

--- a/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
@@ -103,15 +103,6 @@ public class GameService {
 		Player player = gameStatus.getPlayer(gameRollDiceRequest.getPlayerId());
 		int startLocation = player.getLocation();
 
-//		if (startLocation == 6) {
-//			// 탈출 시도 or 보석금
-//			return null;
-//		}
-//		if (startLocation == 18) {
-//			// 순간 이동 진행
-//			return null;
-//		}
-
 		int dice1 = (int)(Math.random() * 6) + 1;
 		int dice2 = (int)(Math.random() * 6) + 1;
 


### PR DESCRIPTION
## 📌 이슈번호
- #50 #51 

## 🔑 Key changes
- 감옥 탈출하기
- 감옥 보석금 내기
- 세금 징수
- 게임방 입장 중복 불가 처리
- 게임방 입장 시 전체현황판 추가 응답
- 게임 준비 상태 취소 안 되는 것 처리
- 이벤트 이름 길이 조절  
`성공적인 맥도날드, 농심 콜라보` → `맥도날드x농심 콜라보!`

## 👋 To reviewers
- 컨트롤러에서 switch로 cell 구분.. 괜찮을까..
- 보석금과 세금은 같은 expense 타입
- 입장 중복 방지는 websocket session 에 playerId attritute 를 추가하였습니다.
- 전체현황판은 무비가 만든 메서드 사용

closed #50 #51