### PR TITLE
[BE] 칸도착-황금카드, 소켓 에러처리, 오타 수정

### DIFF
--- a/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
@@ -181,7 +181,11 @@ public class GameController {
 
 	private void actCell(Long gameId, GameCellResponse gameCellResponse) {
 		switch (gameCellResponse.getLocation()) {
-			case 0, 6, 18, 9, 21: // 시작, 감옥, 순간이동, 황금카드, 황금카드
+			case 0, 6, 18: // 시작, 감옥, 순간이동
+				break;
+			case 9, 21: // 황금카드
+				socketDataSender.send(gameId, new ResponseDTO<>(TypeConstants.GOLD_CARD,
+					gameService.selectGoldCard(gameId, gameCellResponse.getPlayerId())));
 				break;
 			case 12: // 호재
 				socketDataSender.send(gameId, new ResponseDTO<>(TypeConstants.STATUS_BOARD,

--- a/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/controller/GameController.java
@@ -96,8 +96,10 @@ public class GameController {
 	}
 
 	public void enterGame(Long gameId, WebSocketSession session, String playerId) {
-		socketDataSender.saveSocket(gameId, playerId, session);
-		socketDataSender.send(gameId, new ResponseDTO<>(TypeConstants.ENTER, gameService.enterGame(gameId, playerId)));
+		if (socketDataSender.saveSocket(gameId, playerId, session)) {
+			socketDataSender.send(gameId,
+				new ResponseDTO<>(TypeConstants.ENTER, gameService.enterGame(gameId, playerId)));
+		}
 	}
 
 	@GetMapping("/api/games/{gameId}")

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/SocketErrorResponse.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/SocketErrorResponse.java
@@ -1,0 +1,16 @@
+package codesquad.gaemimarble.game.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SocketErrorResponse {
+	private String errorType; // 나중에 에러 코드로 변경
+	private String message;
+
+	@Builder
+	public SocketErrorResponse(String errorType, String message) {
+		this.errorType = errorType;
+		this.message = message;
+	}
+}

--- a/be/src/main/java/codesquad/gaemimarble/game/dto/response/GameGoldCardResponse.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/dto/response/GameGoldCardResponse.java
@@ -1,0 +1,16 @@
+package codesquad.gaemimarble.game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class GameGoldCardResponse {
+	private String title;
+	private String description;
+
+	@Builder
+	private GameGoldCardResponse(String title, String description) {
+		this.title = title;
+		this.description = description;
+	}
+}

--- a/be/src/main/java/codesquad/gaemimarble/game/entity/GoldCard.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/entity/GoldCard.java
@@ -1,0 +1,20 @@
+package codesquad.gaemimarble.game.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum GoldCard {
+	ROB("강탈", "선택한 플레이어에게서 1000만원을 강탈한다.");
+
+	private final String title;
+	private final String description;
+
+	GoldCard(String title, String description) {
+		this.title = title;
+		this.description = description;
+	}
+
+	public static GoldCard getRandomGoldCard() {
+		return GoldCard.values()[(int) (Math.random() * GoldCard.values().length)];
+	}
+}

--- a/be/src/main/java/codesquad/gaemimarble/game/entity/TypeConstants.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/entity/TypeConstants.java
@@ -18,4 +18,5 @@ public final class TypeConstants {
 	public static final String BAIL = "bail";
 	public static final String USER_STATUS_BOARD = "userStatusBoard";
 	public static final String GOLD_CARD = "goldCard";
+	public static final String ERROR = "error";
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/entity/TypeConstants.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/entity/TypeConstants.java
@@ -17,4 +17,5 @@ public final class TypeConstants {
 	public static final String PRISON_DICE = "prisonDice";
 	public static final String BAIL = "bail";
 	public static final String USER_STATUS_BOARD = "userStatusBoard";
+	public static final String GOLD_CARD = "goldCard";
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
@@ -27,6 +27,7 @@ import codesquad.gaemimarble.game.dto.response.GameEventListResponse;
 import codesquad.gaemimarble.game.dto.response.GameEventNameResponse;
 import codesquad.gaemimarble.game.dto.response.GameEventResponse;
 import codesquad.gaemimarble.game.dto.response.GameExpenseResponse;
+import codesquad.gaemimarble.game.dto.response.GameGoldCardResponse;
 import codesquad.gaemimarble.game.dto.response.GamePrisonDiceResponse;
 import codesquad.gaemimarble.game.dto.response.GameReadyResponse;
 import codesquad.gaemimarble.game.dto.response.GameRoomCreateResponse;
@@ -36,6 +37,7 @@ import codesquad.gaemimarble.game.entity.Board;
 import codesquad.gaemimarble.game.entity.CurrentPlayerInfo;
 import codesquad.gaemimarble.game.entity.Events;
 import codesquad.gaemimarble.game.entity.GameStatus;
+import codesquad.gaemimarble.game.entity.GoldCard;
 import codesquad.gaemimarble.game.entity.Player;
 import codesquad.gaemimarble.game.entity.Stock;
 import codesquad.gaemimarble.game.entity.Theme;
@@ -383,5 +385,13 @@ public class GameService {
 			.stream()
 			.map(this::createUserBoardResponse)
 			.toList();
+	}
+
+	public GameGoldCardResponse selectGoldCard(Long gameId, String playerId) {
+		GoldCard goldCard = GoldCard.getRandomGoldCard();
+		return GameGoldCardResponse.builder()
+			.title(goldCard.getTitle())
+			.description(goldCard.getDescription())
+			.build();
 	}
 }

--- a/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
+++ b/be/src/main/java/codesquad/gaemimarble/game/service/GameService.java
@@ -398,7 +398,7 @@ public class GameService {
 	public List<Player> rob(GameRobRequest gameRobRequest) {
 		Player taker = gameRepository.getPlayer(gameRobRequest.getGameId(), gameRobRequest.getPlayerId());
 		taker.addCashAsset(10_000_000);
-		Player target = gameRepository.getPlayer(gameRobRequest.getGameId(), gameRobRequest.getPlayerId());
+		Player target = gameRepository.getPlayer(gameRobRequest.getGameId(), gameRobRequest.getTargetId());
 		target.addCashAsset(-10_000_000);
 		return List.of(taker, target);
 	}


### PR DESCRIPTION
## 📌 이슈번호
- #66 

## 🔑 Key changes
- 칸 도착 황금카드 시 랜덤 카드 지급
- 소켓 에러 처리 (중복 유저, 4인 초과 입장 제한)
- rob 오타 수정

## 👋 To reviewers
- 소켓 에러는 메시지로 반환되어 type : "error" 이면 클라이언트에서 소켓 연결을 끊어주셔야 합니다.